### PR TITLE
Raise exception when performing listdir on non existing folder

### DIFF
--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -377,10 +377,14 @@ class S3FS(FS):
                     _name = _prefix[prefix_len:]
                     if _name:
                         _directory.append(_name.rstrip(self.delimiter))
-                for obj in result.get("Contents", ()):
-                    name = obj["Key"][prefix_len:]
-                    if name:
-                        _directory.append(name)
+                contents = result.get("Contents")
+                if contents:
+                    for obj in contents:
+                        name = obj["Key"][prefix_len:]
+                        if name:
+                            _directory.append(name)
+                else:
+                    raise errors.ResourceNotFound(path)
 
         if self.strict and not _directory:
             if not self.getinfo(_path).is_dir:


### PR DESCRIPTION
First of all, thanks for your fork. This code is very useful for projects that are non using pyfilesystem2 from the beginning on s3 and thus struggle to use the original s3fs module. 

I noticed that listdir behaves differently as compared to other modules such as osfs, or ufficial S3FS module. Listdir on non existing folders usually raises errors.ResourceNotFound(path), whereas infs-s3fs-ng it just returns an empty list. 

I you think this is useful, the proposed PR should make this behavior consistent also in fs-s3fs-ng  

Let me know